### PR TITLE
S3, DB 接続のタイムアウトを10秒に設定

### DIFF
--- a/domain/lgtm_image_repository.go
+++ b/domain/lgtm_image_repository.go
@@ -1,6 +1,8 @@
 package domain
 
+import "context"
+
 type LgtmImageRepository interface {
-	FindAllIds() ([]int32, error)
-	FindByIds(ids []int32) ([]LgtmImageObject, error)
+	FindAllIds(context.Context) ([]int32, error)
+	FindByIds(context.Context, []int32) ([]LgtmImageObject, error)
 }

--- a/domain/s3_repository.go
+++ b/domain/s3_repository.go
@@ -1,5 +1,7 @@
 package domain
 
+import "context"
+
 type S3Repository interface {
-	Upload(param *UploadS3param) error
+	Upload(context.Context, *UploadS3param) error
 }

--- a/handler/create_lgtm_image.go
+++ b/handler/create_lgtm_image.go
@@ -27,7 +27,7 @@ func (h *CreateLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	image, err := h.CreateLgtmImageUseCase.CreateLgtmImage(req)
+	image, err := h.CreateLgtmImageUseCase.CreateLgtmImage(r.Context(), req)
 	if err != nil {
 		switch errors.Cause(err) {
 		case domain.ErrBadRequest:

--- a/handler/extract_random_images.go
+++ b/handler/extract_random_images.go
@@ -20,7 +20,7 @@ type ExtractRandomImagesResponse struct {
 
 func (h *ExtractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Request) {
 
-	lgtmImages, err := h.ExtractRandomImagesUseCase.ExtractRandomImages()
+	lgtmImages, err := h.ExtractRandomImagesUseCase.ExtractRandomImages(r.Context())
 	if err != nil {
 		switch errors.Cause(err) {
 		default:

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"context"
+	"time"
 
 	db "github.com/nekochans/lgtm-cat-api/db/sqlc"
 	"github.com/nekochans/lgtm-cat-api/domain"
@@ -12,7 +13,7 @@ type LgtmImageRepository struct {
 }
 
 func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
-	ctx := context.Background()
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	ids, err := r.Db.ListLgtmImageIds(ctx)
 	if err != nil {
@@ -23,7 +24,7 @@ func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
 }
 
 func (r *LgtmImageRepository) FindByIds(ids []int32) ([]domain.LgtmImageObject, error) {
-	ctx := context.Background()
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	var listLgtmImagesParams = db.ListLgtmImagesParams{
 		ID:   ids[0],

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -12,8 +12,8 @@ type LgtmImageRepository struct {
 	Db *db.Queries
 }
 
-func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (r *LgtmImageRepository) FindAllIds(c context.Context) ([]int32, error) {
+	ctx, cancel := context.WithTimeout(c, 10*time.Second)
 	defer cancel()
 
 	ids, err := r.Db.ListLgtmImageIds(ctx)
@@ -24,8 +24,8 @@ func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
 	return ids, nil
 }
 
-func (r *LgtmImageRepository) FindByIds(ids []int32) ([]domain.LgtmImageObject, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (r *LgtmImageRepository) FindByIds(c context.Context, ids []int32) ([]domain.LgtmImageObject, error) {
+	ctx, cancel := context.WithTimeout(c, 10*time.Second)
 	defer cancel()
 
 	var listLgtmImagesParams = db.ListLgtmImagesParams{

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -13,7 +13,8 @@ type LgtmImageRepository struct {
 }
 
 func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	ids, err := r.Db.ListLgtmImageIds(ctx)
 	if err != nil {
@@ -24,7 +25,8 @@ func (r *LgtmImageRepository) FindAllIds() ([]int32, error) {
 }
 
 func (r *LgtmImageRepository) FindByIds(ids []int32) ([]domain.LgtmImageObject, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	var listLgtmImagesParams = db.ListLgtmImagesParams{
 		ID:   ids[0],

--- a/infrastructure/s3_repository.go
+++ b/infrastructure/s3_repository.go
@@ -29,7 +29,8 @@ func decideS3ContentType(ext string) string {
 }
 
 func (r *S3Repository) Upload(param *domain.UploadS3param) error {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	input := &s3.PutObjectInput{
 		Bucket:      aws.String(r.S3Bucket),

--- a/infrastructure/s3_repository.go
+++ b/infrastructure/s3_repository.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -28,7 +29,7 @@ func decideS3ContentType(ext string) string {
 }
 
 func (r *S3Repository) Upload(param *domain.UploadS3param) error {
-	ctx := context.Background()
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	input := &s3.PutObjectInput{
 		Bucket:      aws.String(r.S3Bucket),

--- a/infrastructure/s3_repository.go
+++ b/infrastructure/s3_repository.go
@@ -28,8 +28,8 @@ func decideS3ContentType(ext string) string {
 	return contentType
 }
 
-func (r *S3Repository) Upload(param *domain.UploadS3param) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (r *S3Repository) Upload(c context.Context, param *domain.UploadS3param) error {
+	ctx, cancel := context.WithTimeout(c, 10*time.Second)
 	defer cancel()
 
 	input := &s3.PutObjectInput{

--- a/usecase/create_lgtm_image.go
+++ b/usecase/create_lgtm_image.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"time"
@@ -19,7 +20,7 @@ type requestBody struct {
 	ImageExtension string `json:"imageExtension"`
 }
 
-func (u *CreateLgtmImageUseCase) CreateLgtmImage(req []byte) (*domain.UploadedLgtmImage, error) {
+func (u *CreateLgtmImageUseCase) CreateLgtmImage(ctx context.Context, req []byte) (*domain.UploadedLgtmImage, error) {
 
 	var reqBody requestBody
 	if err := json.Unmarshal(req, &reqBody); err != nil {
@@ -55,7 +56,7 @@ func (u *CreateLgtmImageUseCase) CreateLgtmImage(req []byte) (*domain.UploadedLg
 		reqBody.ImageExtension,
 	)
 
-	err = u.Repository.Upload(uploadS3param)
+	err = u.Repository.Upload(ctx, uploadS3param)
 	if err != nil {
 		return nil, domain.ErrUploadToS3
 	}

--- a/usecase/extract_random_images.go
+++ b/usecase/extract_random_images.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"log"
 	"math/rand"
 	"time"
@@ -40,8 +41,8 @@ func pickupRandomIdsNoDuplicates(ids []int32, listCount int) []int32 {
 	return randomIds
 }
 
-func (u *ExtractRandomImagesUseCase) ExtractRandomImages() ([]domain.LgtmImage, error) {
-	ids, err := u.Repository.FindAllIds()
+func (u *ExtractRandomImagesUseCase) ExtractRandomImages(ctx context.Context) ([]domain.LgtmImage, error) {
+	ids, err := u.Repository.FindAllIds(ctx)
 	if err != nil {
 		return nil, domain.ErrCountRecords
 	}
@@ -52,7 +53,7 @@ func (u *ExtractRandomImagesUseCase) ExtractRandomImages() ([]domain.LgtmImage, 
 
 	var randomIds = pickupRandomIdsNoDuplicates(ids, domain.FetchLgtmImageCount)
 
-	rows, err := u.Repository.FindByIds(randomIds)
+	rows, err := u.Repository.FindByIds(ctx, randomIds)
 	if err != nil {
 		return nil, domain.ErrFetchImages
 	}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/14

# Doneの定義
S3やRDSの接続に失敗した場合、アプリケーションで定義したエラーがレスポンスとして返ること
( context でタイムアウトを30秒以内に設定することで回避する)

# 変更点概要
- S3, DB 接続のタイムアウトを10秒に設定(タイムアウトの適切な時間がわからず10秒に設定した。)

またIssueとは関係ないが下記の変更も合わせて対応している。
-  http.Request の context を repository まで引回す形に変更