### PR TITLE
ユニークなIDを生成をする repository を作成し domain 層で処理していた uuid の生成を移動

### DIFF
--- a/domain/create_lgtm_image_usecase.go
+++ b/domain/create_lgtm_image_usecase.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"bytes"
 	"errors"
-	"github.com/google/uuid"
 	"time"
 )
 
@@ -43,12 +42,8 @@ func CanConvertImageExtension(ext string) bool {
 	return true
 }
 
-func GenerateImageName() (string, error) {
-	uid, err := uuid.NewRandom()
-	if err != nil {
-		return "", err
-	}
-	return uid.String(), nil
+func GenerateImageName(u UniqueIdGenerator) (string, error) {
+	return u.Generate()
 }
 
 func BuildS3Prefix(t time.Time) (string, error) {

--- a/domain/unique_id_generator.go
+++ b/domain/unique_id_generator.go
@@ -1,0 +1,5 @@
+package domain
+
+type UniqueIdGenerator interface {
+	Generate() (string, error)
+}

--- a/infrastructure/unique_id_generator.go
+++ b/infrastructure/unique_id_generator.go
@@ -1,0 +1,16 @@
+package infrastructure
+
+import (
+	"github.com/google/uuid"
+)
+
+type UuidGenerator struct{}
+
+func (g *UuidGenerator) Generate() (string, error) {
+	uid, err := uuid.NewRandom()
+	if err != nil {
+		return "", err
+	}
+
+	return uid.String(), nil
+}

--- a/usecase/createltgmimage/usecase.go
+++ b/usecase/createltgmimage/usecase.go
@@ -7,17 +7,20 @@ import (
 	"time"
 
 	"github.com/nekochans/lgtm-cat-api/domain"
+	"github.com/nekochans/lgtm-cat-api/infrastructure"
 )
 
 type UseCase struct {
-	repository domain.S3Repository
-	cdnDomain  string
+	repository  domain.S3Repository
+	cdnDomain   string
+	idGenerator domain.UniqueIdGenerator
 }
 
 func NewUseCase(r domain.S3Repository, c string) *UseCase {
 	return &UseCase{
-		repository: r,
-		cdnDomain:  c,
+		repository:  r,
+		cdnDomain:   c,
+		idGenerator: &infrastructure.UuidGenerator{},
 	}
 }
 
@@ -45,7 +48,7 @@ func (u *UseCase) CreateLgtmImage(ctx context.Context, reqBody RequestBody) (*do
 		return nil, domain.ErrTimeLoadLocation
 	}
 
-	imageName, err := domain.GenerateImageName()
+	imageName, err := domain.GenerateImageName(u.idGenerator)
 	if err != nil {
 		return nil, domain.ErrGenerateUuid
 	}


### PR DESCRIPTION
# issueURL
#27 

# Doneの定義
domain内部で処理しているuuidの生成を外部から渡されるように変更されていること

# 変更点概要
ユニークなIDを生成をする repository を作成し domain 層で処理していた uuid の生成を移動した。
domain 層では repository のインターフェースに依存する形に変更している。
