### PR TITLE
golangci-lint を導入

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,6 @@ linters:
     - errcheck
     - exhaustive
     - funlen
-    - gochecknoinits
     - goconst
     - gocritic
     - gocyclo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,45 @@
+issues:
+  exclude-use-default: false
+
+linters-settings:
+  funlen:
+    lines: 65
+    statements: 40
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - exportloopref
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+.PHONY: lint
+lint:
+	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run -v
+
 .PHONY: deps
 deps:
 	go mod download

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 lint:
 	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run -v
 
+.PHONY: format
+format:
+	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run -v --fix
+
 .PHONY: deps
 deps:
 	go mod download

--- a/domain/create_lgtm_image_usecase.go
+++ b/domain/create_lgtm_image_usecase.go
@@ -56,7 +56,6 @@ func BuildS3Prefix(t time.Time) (string, error) {
 }
 
 func CreateUploadS3param(body *bytes.Buffer, prefix, imageName, imageExtension string) *UploadS3param {
-
 	uploadKey := prefix + imageName + imageExtension
 
 	return &UploadS3param{

--- a/domain/extract_random_images_usecase.go
+++ b/domain/extract_random_images_usecase.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"github.com/pkg/errors"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/handler/create_lgtm_image.go
+++ b/handler/create_lgtm_image.go
@@ -57,6 +57,4 @@ func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 	fmt.Fprint(w, string(responseJson))
 	w.WriteHeader(202)
 	w.Header().Add("Content-Type", "application/json")
-
-	return
 }

--- a/handler/create_lgtm_image.go
+++ b/handler/create_lgtm_image.go
@@ -26,7 +26,6 @@ type CreateLgtmImageResponse struct {
 }
 
 func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) {
-
 	req, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		RenderErrorResponse(w, http.StatusInternalServerError, "Failed Read Request Body")

--- a/handler/create_lgtm_image.go
+++ b/handler/create_lgtm_image.go
@@ -29,13 +29,13 @@ func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 
 	req, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		RenderErrorResponse(w, 500, "Failed Read Request Body")
+		RenderErrorResponse(w, http.StatusInternalServerError, "Failed Read Request Body")
 		return
 	}
 
 	var reqBody createltgmimage.RequestBody
 	if err := json.Unmarshal(req, &reqBody); err != nil {
-		RenderErrorResponse(w, 400, err.Error())
+		RenderErrorResponse(w, http.StatusBadRequest, err.Error())
 	}
 
 	image, err := h.useCase.CreateLgtmImage(r.Context(), reqBody)
@@ -44,9 +44,9 @@ func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 		case domain.ErrInvalidImageExtension:
 			fmt.Println(err)
 
-			RenderErrorResponse(w, 422, err.Error())
+			RenderErrorResponse(w, http.StatusUnprocessableEntity, err.Error())
 		default:
-			RenderErrorResponse(w, 500, err.Error())
+			RenderErrorResponse(w, http.StatusInternalServerError, err.Error())
 		}
 
 		return
@@ -55,6 +55,6 @@ func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 	response := &CreateLgtmImageResponse{ImageUrl: image.Url}
 	responseJson, _ := json.Marshal(response)
 	fmt.Fprint(w, string(responseJson))
-	w.WriteHeader(202)
+	w.WriteHeader(http.StatusAccepted)
 	w.Header().Add("Content-Type", "application/json")
 }

--- a/handler/extract_random_images.go
+++ b/handler/extract_random_images.go
@@ -41,6 +41,4 @@ func (h *extractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Requ
 	fmt.Fprint(w, string(responseJson))
 	w.WriteHeader(200)
 	w.Header().Add("Content-Type", "application/json")
-
-	return
 }

--- a/handler/extract_random_images.go
+++ b/handler/extract_random_images.go
@@ -30,7 +30,7 @@ func (h *extractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		switch errors.Cause(err) {
 		default:
-			RenderErrorResponse(w, 500, err.Error())
+			RenderErrorResponse(w, http.StatusInternalServerError, err.Error())
 		}
 
 		return
@@ -39,6 +39,6 @@ func (h *extractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Requ
 	response := &ExtractRandomImagesResponse{LgtmImages: lgtmImages}
 	responseJson, _ := json.Marshal(response)
 	fmt.Fprint(w, string(responseJson))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "application/json")
 }

--- a/handler/extract_random_images.go
+++ b/handler/extract_random_images.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/nekochans/lgtm-cat-api/domain"
 	"github.com/nekochans/lgtm-cat-api/usecase/extractrandomimages"
-	"github.com/pkg/errors"
 )
 
 type extractRandomImagesHandler struct {
@@ -27,11 +26,7 @@ type ExtractRandomImagesResponse struct {
 func (h *extractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Request) {
 	lgtmImages, err := h.useCase.ExtractRandomImages(r.Context())
 	if err != nil {
-		switch errors.Cause(err) {
-		default:
-			RenderErrorResponse(w, http.StatusInternalServerError, err.Error())
-		}
-
+		RenderErrorResponse(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/handler/extract_random_images.go
+++ b/handler/extract_random_images.go
@@ -25,7 +25,6 @@ type ExtractRandomImagesResponse struct {
 }
 
 func (h *extractRandomImagesHandler) Extract(w http.ResponseWriter, r *http.Request) {
-
 	lgtmImages, err := h.useCase.ExtractRandomImages(r.Context())
 	if err != nil {
 		switch errors.Cause(err) {

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -12,12 +12,14 @@ type lgtmImageRepository struct {
 	db *db.Queries
 }
 
+const dbTimeoutSecond = 10
+
 func NewLgtmImageRepository(db *db.Queries) *lgtmImageRepository {
 	return &lgtmImageRepository{db: db}
 }
 
 func (r *lgtmImageRepository) FindAllIds(c context.Context) ([]int32, error) {
-	ctx, cancel := context.WithTimeout(c, 10*time.Second)
+	ctx, cancel := context.WithTimeout(c, dbTimeoutSecond*time.Second)
 	defer cancel()
 
 	ids, err := r.db.ListLgtmImageIds(ctx)
@@ -29,7 +31,7 @@ func (r *lgtmImageRepository) FindAllIds(c context.Context) ([]int32, error) {
 }
 
 func (r *lgtmImageRepository) FindByIds(c context.Context, ids []int32) ([]domain.LgtmImageObject, error) {
-	ctx, cancel := context.WithTimeout(c, 10*time.Second)
+	ctx, cancel := context.WithTimeout(c, dbTimeoutSecond*time.Second)
 	defer cancel()
 
 	var listLgtmImagesParams = db.ListLgtmImagesParams{

--- a/infrastructure/s3_repository.go
+++ b/infrastructure/s3_repository.go
@@ -31,9 +31,9 @@ func decideS3ContentType(ext string) string {
 
 	return contentType
 }
-
 func (r *s3Repository) Upload(c context.Context, param *domain.UploadS3param) error {
-	ctx, cancel := context.WithTimeout(c, 10*time.Second)
+	const s3timeoutSecond = 10
+	ctx, cancel := context.WithTimeout(c, s3timeoutSecond*time.Second)
 	defer cancel()
 
 	input := &s3.PutObjectInput{

--- a/main.go
+++ b/main.go
@@ -57,7 +57,6 @@ func init() {
 }
 
 func Handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-
 	s3Repository := infrastructure.NewS3Repository(uploader, uploadS3Bucket)
 	createLgtmImageUseCase := createltgmimage.NewUseCase(s3Repository, lgtmImagesCdnDomain)
 	createLgtmImageHandler := handler.NewCreateLgtmImageHandler(createLgtmImageUseCase)

--- a/usecase/createltgmimage/usecase.go
+++ b/usecase/createltgmimage/usecase.go
@@ -30,7 +30,6 @@ type RequestBody struct {
 }
 
 func (u *UseCase) CreateLgtmImage(ctx context.Context, reqBody RequestBody) (*domain.UploadedLgtmImage, error) {
-
 	if !domain.CanConvertImageExtension(reqBody.ImageExtension) {
 		return nil, domain.ErrInvalidImageExtension
 	}

--- a/usecase/extractrandomimages/usecase.go
+++ b/usecase/extractrandomimages/usecase.go
@@ -36,7 +36,7 @@ func pickupRandomIdsNoDuplicates(ids []int32, listCount int) []int32 {
 
 	var randomIds []int32
 	for i := 1; i <= listCount; {
-		n := rand.Intn(recordCount - 1)
+		n := rand.Intn(recordCount - 1) //nolint:gosec
 		if contains(randomIds, ids[n]) {
 			continue
 		}

--- a/usecase/extractrandomimages/usecase.go
+++ b/usecase/extractrandomimages/usecase.go
@@ -31,7 +31,6 @@ func contains(elems []int32, v int32) bool {
 }
 
 func pickupRandomIdsNoDuplicates(ids []int32, listCount int) []int32 {
-
 	rand.Seed(time.Now().Unix())
 	recordCount := len(ids)
 


### PR DESCRIPTION
# issueURL
#19 

# Doneの定義
#19 の完了条件が満たされていること

# 変更点概要
ローカルでLinterを実行できるように `golangci-lint`の設定を追加。

`.golangci.yml` は下記を参考に設定した。
https://github.com/nekochans/portfolio-backend/blob/main/.golangci.yml

上記は、`golangci-lint`の v1.42.1 を利用している。今回の設定では v1.44.2 を利用しているため、v1.42.1 -> v1.44.2 で非推奨になったLinterがないか確認したが存在しなかった。また、RDS へのコネクションを維持するために init() を利用したいので gochecknoinits を削除している。

# 補足情報
CIの設定は別の課題で対応するので、ローカルで実行できるところまで対応した。