### PR TITLE
createltgmimage usecase のテストを追加

### DIFF
--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -1,0 +1,69 @@
+package createltgmimage
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nekochans/lgtm-cat-api/domain"
+)
+
+type mockUniqueIdGenerator struct {
+	domain.UniqueIdGenerator
+	FakeGenerate func() (string, error)
+}
+
+func (d *mockUniqueIdGenerator) Generate() (string, error) {
+	return d.FakeGenerate()
+}
+
+type mockS3Repository struct {
+	domain.S3Repository
+	FakeUpload func(context.Context, *domain.UploadS3param) error
+}
+
+func (d *mockS3Repository) Upload(c context.Context, u *domain.UploadS3param) error {
+	return d.FakeUpload(c, u)
+}
+
+func TestNewUseCase(t *testing.T) {
+	t.Run("Success create LGTM image", func(t *testing.T) {
+		s3Mock := &mockS3Repository{
+			FakeUpload: func(context.Context, *domain.UploadS3param) error {
+				return nil
+			},
+		}
+		idGenMock := &mockUniqueIdGenerator{
+			FakeGenerate: func() (string, error) {
+				return "testimagename", nil
+			},
+		}
+		imageName := "testimagename"
+
+		u := &UseCase{
+			repository:  s3Mock,
+			idGenerator: idGenMock,
+			cdnDomain:   imageName,
+		}
+
+		r := &RequestBody{
+			Image:          "",
+			ImageExtension: ".png",
+		}
+		ctx := context.Background()
+		res, err := u.CreateLgtmImage(ctx, *r)
+		if err != nil {
+			t.Fatalf("エラーにならないはずなのにエラーになった %v", err)
+		}
+
+		prefix, _ := domain.BuildS3Prefix(time.Now().UTC())
+		expected := &domain.UploadedLgtmImage{
+			Url: "https://" + u.cdnDomain + "/" + prefix + imageName + ".webp",
+		}
+
+		if reflect.DeepEqual(res, expected) == false {
+			t.Error("\nwant: ", res, "\ngot: ", expected)
+		}
+	})
+}

--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -2,6 +2,7 @@ package createltgmimage
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -27,7 +28,10 @@ func (d *mockS3Repository) Upload(c context.Context, u *domain.UploadS3param) er
 	return d.FakeUpload(c, u)
 }
 
+//nolint:funlen
 func TestNewUseCase(t *testing.T) {
+	imageName := "test-image-name"
+
 	t.Run("Success create LGTM image", func(t *testing.T) {
 		s3Mock := &mockS3Repository{
 			FakeUpload: func(context.Context, *domain.UploadS3param) error {
@@ -36,11 +40,9 @@ func TestNewUseCase(t *testing.T) {
 		}
 		idGenMock := &mockUniqueIdGenerator{
 			FakeGenerate: func() (string, error) {
-				return "testimagename", nil
+				return imageName, nil
 			},
 		}
-		imageName := "testimagename"
-
 		u := &UseCase{
 			repository:  s3Mock,
 			idGenerator: idGenMock,
@@ -54,16 +56,118 @@ func TestNewUseCase(t *testing.T) {
 		ctx := context.Background()
 		res, err := u.CreateLgtmImage(ctx, *r)
 		if err != nil {
-			t.Fatalf("エラーにならないはずなのにエラーになった %v", err)
+			t.Fatalf("unexpected err = %s", err)
 		}
 
 		prefix, _ := domain.BuildS3Prefix(time.Now().UTC())
-		expected := &domain.UploadedLgtmImage{
+		want := &domain.UploadedLgtmImage{
 			Url: "https://" + u.cdnDomain + "/" + prefix + imageName + ".webp",
 		}
 
-		if reflect.DeepEqual(res, expected) == false {
-			t.Error("\nwant: ", res, "\ngot: ", expected)
+		if reflect.DeepEqual(res, want) == false {
+			t.Errorf("\nwant\n%s\ngot\n%s", want, res)
+		}
+	})
+
+	t.Run("Failure unexpect image extension", func(t *testing.T) {
+		s3Mock := &mockS3Repository{
+			FakeUpload: func(context.Context, *domain.UploadS3param) error {
+				return nil
+			},
+		}
+		idGenMock := &mockUniqueIdGenerator{
+			FakeGenerate: func() (string, error) {
+				return imageName, nil
+			},
+		}
+		u := &UseCase{
+			repository:  s3Mock,
+			idGenerator: idGenMock,
+			cdnDomain:   imageName,
+		}
+
+		r := &RequestBody{
+			Image:          "",
+			ImageExtension: ".webp",
+		}
+
+		ctx := context.Background()
+		_, err := u.CreateLgtmImage(ctx, *r)
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		if !errors.Is(err, domain.ErrInvalidImageExtension) {
+			t.Fatalf("\nwant\n%s\ngot\n%s", domain.ErrInvalidImageExtension, err)
+		}
+	})
+
+	t.Run("Failure generate image name", func(t *testing.T) {
+		s3Mock := &mockS3Repository{
+			FakeUpload: func(context.Context, *domain.UploadS3param) error {
+				return nil
+			},
+		}
+		idGenMock := &mockUniqueIdGenerator{
+			FakeGenerate: func() (string, error) {
+				return "", errors.New("dummy error")
+			},
+		}
+		u := &UseCase{
+			repository:  s3Mock,
+			idGenerator: idGenMock,
+			cdnDomain:   imageName,
+		}
+
+		r := &RequestBody{
+			Image:          "",
+			ImageExtension: ".png",
+		}
+
+		ctx := context.Background()
+		_, err := u.CreateLgtmImage(ctx, *r)
+
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		var want *domain.ErrGenerateImageName
+		if !errors.As(err, &want) {
+			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
+		}
+	})
+
+	t.Run("Failure upload image to s3", func(t *testing.T) {
+		s3Mock := &mockS3Repository{
+			FakeUpload: func(context.Context, *domain.UploadS3param) error {
+				return &domain.S3Error{
+					Op:  "Upload",
+					Err: errors.New("s3 upload dummy error"),
+				}
+			},
+		}
+		idGenMock := &mockUniqueIdGenerator{
+			FakeGenerate: func() (string, error) {
+				return imageName, nil
+			},
+		}
+		u := &UseCase{
+			repository:  s3Mock,
+			idGenerator: idGenMock,
+			cdnDomain:   imageName,
+		}
+
+		r := &RequestBody{
+			Image:          "",
+			ImageExtension: ".png",
+		}
+
+		ctx := context.Background()
+		_, err := u.CreateLgtmImage(ctx, *r)
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		var want *domain.S3Error
+		if !errors.As(err, &want) {
+			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
 		}
 	})
 }


### PR DESCRIPTION
# issueURL
#21 

# Doneの定義
createltgmimage usecase のテストケースが追加されていること

# 変更点概要
createltgmimage usecaseのテストを追加。
先にテストの方針を確認したいので、もう1 つの usecase extractrandomimages については別のPRで対応する。

テスト方針
- infrastructure のメソッドをモックにし、正常系と異常系のテストケースを追加した
- 異常系のテストでは、domain に定義したエラーが返ってきていることをテストしている

# レビュアーに重点的にチェックして欲しい点
テスト方針として問題ないかどうか