### PR TITLE
extractrandomimages usecase のテストを追加

### DIFF
--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -29,7 +29,7 @@ func (d *mockS3Repository) Upload(c context.Context, u *domain.UploadS3param) er
 }
 
 //nolint:funlen
-func TestNewUseCase(t *testing.T) {
+func TestCreateLgtmImage(t *testing.T) {
 	imageName := "test-image-name"
 
 	t.Run("Success create LGTM image", func(t *testing.T) {

--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -31,6 +31,7 @@ func (d *mockS3Repository) Upload(c context.Context, u *domain.UploadS3param) er
 //nolint:funlen
 func TestCreateLgtmImage(t *testing.T) {
 	imageName := "test-image-name"
+	cdnDomain := "lgtm-images.lgtmeow.com"
 
 	t.Run("Success create LGTM image", func(t *testing.T) {
 		s3Mock := &mockS3Repository{
@@ -43,10 +44,11 @@ func TestCreateLgtmImage(t *testing.T) {
 				return imageName, nil
 			},
 		}
+
 		u := &UseCase{
 			repository:  s3Mock,
 			idGenerator: idGenMock,
-			cdnDomain:   imageName,
+			cdnDomain:   cdnDomain,
 		}
 
 		r := &RequestBody{
@@ -83,7 +85,7 @@ func TestCreateLgtmImage(t *testing.T) {
 		u := &UseCase{
 			repository:  s3Mock,
 			idGenerator: idGenMock,
-			cdnDomain:   imageName,
+			cdnDomain:   cdnDomain,
 		}
 
 		r := &RequestBody{
@@ -115,7 +117,7 @@ func TestCreateLgtmImage(t *testing.T) {
 		u := &UseCase{
 			repository:  s3Mock,
 			idGenerator: idGenMock,
-			cdnDomain:   imageName,
+			cdnDomain:   cdnDomain,
 		}
 
 		r := &RequestBody{
@@ -152,7 +154,7 @@ func TestCreateLgtmImage(t *testing.T) {
 		u := &UseCase{
 			repository:  s3Mock,
 			idGenerator: idGenMock,
-			cdnDomain:   imageName,
+			cdnDomain:   cdnDomain,
 		}
 
 		r := &RequestBody{

--- a/usecase/extractrandomimages/usecase.go
+++ b/usecase/extractrandomimages/usecase.go
@@ -36,7 +36,7 @@ func pickupRandomIdsNoDuplicates(ids []int32, listCount int) []int32 {
 
 	var randomIds []int32
 	for i := 1; i <= listCount; {
-		n := rand.Intn(recordCount - 1) //nolint:gosec
+		n := rand.Intn(recordCount) //nolint:gosec
 		if contains(randomIds, ids[n]) {
 			continue
 		}

--- a/usecase/extractrandomimages/usecase_test.go
+++ b/usecase/extractrandomimages/usecase_test.go
@@ -1,0 +1,166 @@
+package extractrandomimages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/nekochans/lgtm-cat-api/domain"
+)
+
+type mockLgtmImageRepository struct {
+	domain.LgtmImageRepository
+	FakeFindAllIds func(context.Context) ([]int32, error)
+	FakeFindByIds  func(context.Context, []int32) ([]domain.LgtmImageObject, error)
+}
+
+func (m *mockLgtmImageRepository) FindAllIds(c context.Context) ([]int32, error) {
+	return m.FakeFindAllIds(c)
+}
+
+func (m *mockLgtmImageRepository) FindByIds(c context.Context, ids []int32) ([]domain.LgtmImageObject, error) {
+	return m.FakeFindByIds(c, ids)
+}
+
+//nolint:funlen
+func TestExtractRandomImages(t *testing.T) {
+	cdnDomain := "lgtm-images.lgtmeow.com"
+
+	t.Run("Success extract random images", func(t *testing.T) {
+		var findByIdsMockResponse []domain.LgtmImageObject
+		for i := 1; i < 20; i++ {
+			findByIdsMockResponse = append(
+				findByIdsMockResponse,
+				domain.LgtmImageObject{Id: int32(i), Path: "2022/02/22/22", Filename: "image-name" + fmt.Sprint(i)})
+		}
+		var ids []int32
+		// TODO pickupRandomIdsNoDuplicates 修正後 +1 を削除する
+		for i := 1; i <= domain.FetchLgtmImageCount+1; i++ {
+			ids = append(
+				ids,
+				int32(i),
+			)
+		}
+
+		mock := &mockLgtmImageRepository{
+			FakeFindAllIds: func(context.Context) ([]int32, error) {
+				return ids, nil
+			},
+			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
+				return findByIdsMockResponse, nil
+			},
+		}
+		u := NewUseCase(mock, cdnDomain)
+
+		ctx := context.Background()
+		res, err := u.ExtractRandomImages(ctx)
+		if err != nil {
+			t.Fatalf("unexpected err = %s", err)
+		}
+
+		var want []domain.LgtmImage
+		for _, v := range findByIdsMockResponse {
+			want = append(want, domain.LgtmImage{
+				Id:  fmt.Sprint(v.Id),
+				Url: "https://" + u.cdnDomain + "/" + v.Path + "/" + v.Filename + ".webp",
+			})
+		}
+
+		if reflect.DeepEqual(res, want) == false {
+			t.Errorf("\nwant\n%s\ngot\n%s", want, res)
+		}
+	})
+
+	t.Run("Failure error record count", func(t *testing.T) {
+		var ids []int32
+		for i := 1; i <= domain.FetchLgtmImageCount-1; i++ {
+			ids = append(
+				ids,
+				int32(i),
+			)
+		}
+
+		mock := &mockLgtmImageRepository{
+
+			FakeFindAllIds: func(context.Context) ([]int32, error) {
+				return ids, nil
+			},
+			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
+				return nil, nil
+			},
+		}
+		u := NewUseCase(mock, cdnDomain)
+
+		ctx := context.Background()
+		_, err := u.ExtractRandomImages(ctx)
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		if !errors.Is(err, domain.ErrRecordCount) {
+			t.Fatalf("\nwant\n%s\ngot\n%s", domain.ErrRecordCount, err)
+		}
+	})
+
+	t.Run("Failure find all ids", func(t *testing.T) {
+		mock := &mockLgtmImageRepository{
+			FakeFindAllIds: func(context.Context) ([]int32, error) {
+				return nil, &domain.LgtmImageError{
+					Op:  "FindAllIds",
+					Err: errors.New("FindAllIds dummy error"),
+				}
+			},
+			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
+				return nil, nil
+			},
+		}
+
+		u := NewUseCase(mock, cdnDomain)
+
+		ctx := context.Background()
+		_, err := u.ExtractRandomImages(ctx)
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		var want *domain.LgtmImageError
+		if !errors.As(err, &want) {
+			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
+		}
+	})
+
+	t.Run("Failure find all ids", func(t *testing.T) {
+		var ids []int32
+		// TODO pickupRandomIdsNoDuplicates 修正後 +1 を削除する
+		for i := 1; i <= domain.FetchLgtmImageCount+1; i++ {
+			ids = append(
+				ids,
+				int32(i),
+			)
+		}
+
+		mock := &mockLgtmImageRepository{
+			FakeFindAllIds: func(context.Context) ([]int32, error) {
+				return ids, nil
+			},
+			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
+				return nil, &domain.LgtmImageError{
+					Op:  "FindByIds",
+					Err: errors.New("FindByIds dummy error"),
+				}
+			},
+		}
+
+		u := NewUseCase(mock, cdnDomain)
+
+		ctx := context.Background()
+		_, err := u.ExtractRandomImages(ctx)
+		if err == nil {
+			t.Fatal("expected to return an error, but no error")
+		}
+		var want *domain.LgtmImageError
+		if !errors.As(err, &want) {
+			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
+		}
+	})
+}

--- a/usecase/extractrandomimages/usecase_test.go
+++ b/usecase/extractrandomimages/usecase_test.go
@@ -29,23 +29,24 @@ func TestExtractRandomImages(t *testing.T) {
 	cdnDomain := "lgtm-images.lgtmeow.com"
 
 	t.Run("Success extract random images", func(t *testing.T) {
+		var findAllIdsResponse []int32
+		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
+			findAllIdsResponse = append(
+				findAllIdsResponse,
+				int32(i),
+			)
+		}
+
 		var findByIdsMockResponse []domain.LgtmImageObject
 		for i := 1; i < 20; i++ {
 			findByIdsMockResponse = append(
 				findByIdsMockResponse,
 				domain.LgtmImageObject{Id: int32(i), Path: "2022/02/22/22", Filename: "image-name" + fmt.Sprint(i)})
 		}
-		var ids []int32
-		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
-			ids = append(
-				ids,
-				int32(i),
-			)
-		}
 
 		mock := &mockLgtmImageRepository{
 			FakeFindAllIds: func(context.Context) ([]int32, error) {
-				return ids, nil
+				return findAllIdsResponse, nil
 			},
 			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
 				return findByIdsMockResponse, nil
@@ -73,18 +74,17 @@ func TestExtractRandomImages(t *testing.T) {
 	})
 
 	t.Run("Failure error record count", func(t *testing.T) {
-		var ids []int32
+		var findAllIdsResponse []int32
 		for i := 1; i <= domain.FetchLgtmImageCount-1; i++ {
-			ids = append(
-				ids,
+			findAllIdsResponse = append(
+				findAllIdsResponse,
 				int32(i),
 			)
 		}
 
 		mock := &mockLgtmImageRepository{
-
 			FakeFindAllIds: func(context.Context) ([]int32, error) {
-				return ids, nil
+				return findAllIdsResponse, nil
 			},
 			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
 				return nil, nil
@@ -129,17 +129,17 @@ func TestExtractRandomImages(t *testing.T) {
 	})
 
 	t.Run("Failure find all ids", func(t *testing.T) {
-		var ids []int32
+		var findAllIdsResponse []int32
 		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
-			ids = append(
-				ids,
+			findAllIdsResponse = append(
+				findAllIdsResponse,
 				int32(i),
 			)
 		}
 
 		mock := &mockLgtmImageRepository{
 			FakeFindAllIds: func(context.Context) ([]int32, error) {
-				return ids, nil
+				return findAllIdsResponse, nil
 			},
 			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
 				return nil, &domain.LgtmImageError{

--- a/usecase/extractrandomimages/usecase_test.go
+++ b/usecase/extractrandomimages/usecase_test.go
@@ -36,8 +36,7 @@ func TestExtractRandomImages(t *testing.T) {
 				domain.LgtmImageObject{Id: int32(i), Path: "2022/02/22/22", Filename: "image-name" + fmt.Sprint(i)})
 		}
 		var ids []int32
-		// TODO pickupRandomIdsNoDuplicates 修正後 +1 を削除する
-		for i := 1; i <= domain.FetchLgtmImageCount+1; i++ {
+		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
 			ids = append(
 				ids,
 				int32(i),
@@ -131,8 +130,7 @@ func TestExtractRandomImages(t *testing.T) {
 
 	t.Run("Failure find all ids", func(t *testing.T) {
 		var ids []int32
-		// TODO pickupRandomIdsNoDuplicates 修正後 +1 を削除する
-		for i := 1; i <= domain.FetchLgtmImageCount+1; i++ {
+		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
 			ids = append(
 				ids,
 				int32(i),


### PR DESCRIPTION
# issueURL
#21 

# 関連URL
同じIssueの別PR
[createltgmimage usecase のテストを追加](https://github.com/nekochans/lgtm-cat-api/pull/31)

# Doneの定義
extractrandomimages usecase のテストが追加されていること

# 変更点概要
- extractrandomimages usecase のテストを追加
- テストケース作成中に既存の不具合も発見したので合わせて修正
    - 不具合内容 
        - `usecase/extractrandomimages/usecase.go` の関数 `pickupRandomIdsNoDuplicates`でDBのレコード数と取得する画像数がイコールであった場合、無限ループが発生する
        - レコード数が取得する画像数より多かった場合も最後にアップロードされた画像がレスポンスに含まれない
    - 修正内容
        - `rand.Intn`の処理を勘違いしていたので、引数を変更