### PR TITLE
usecase fetchlgtmimages RetrieveRecentlyCreatedImages() のDBに接続するテストケースを追加

### DIFF
--- a/test/db_creator.go
+++ b/test/db_creator.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type DbCreator struct{}
+
+func (c *DbCreator) Create() (*sql.DB, error) {
+	dbUser := os.Getenv("TEST_DB_USER")
+	dbPassword := os.Getenv("TEST_DB_PASSWORD")
+	dbHost := os.Getenv("TEST_DB_HOST")
+	dbName := os.Getenv("TEST_DB_NAME")
+
+	dbSourceName := fmt.Sprintf("%s:%s@tcp(%s)/%s", dbUser, dbPassword, dbHost, dbName)
+	db, err := sql.Open("mysql", dbSourceName)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to test mysql server, %s", err)
+	}
+
+	return db, nil
+}

--- a/test/seeder.go
+++ b/test/seeder.go
@@ -1,0 +1,81 @@
+package test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+type Seeder struct {
+	Db      *sql.DB
+	DirPath string
+}
+
+func (s *Seeder) Execute() error {
+	files, err := os.ReadDir(s.DirPath)
+	if err != nil {
+		return fmt.Errorf("failed to read test data dir: %s", err)
+	}
+
+	tx, err := s.Db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %s", err)
+	}
+
+	for _, file := range files {
+		ext := filepath.Ext(file.Name())
+		if ext != ".csv" {
+			continue
+		}
+
+		table := file.Name()[:len(file.Name())-len(ext)]
+		csvFilePath := filepath.Join(s.DirPath, file.Name())
+
+		if _, err := s.loadDataFromCsv(tx, table, csvFilePath); err != nil {
+			if err := tx.Rollback(); err != nil {
+				return fmt.Errorf("failed to transaction rollback: %s", err)
+			}
+
+			return fmt.Errorf("failed to load data from csv: %s", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (s *Seeder) TruncateAllTable() error {
+	tx, err := s.Db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %s", err)
+	}
+
+	if _, err := tx.Exec("TRUNCATE lgtm_images"); err != nil {
+		if err := tx.Rollback(); err != nil {
+			return fmt.Errorf("failed to transaction rollback: %s", err)
+		}
+
+		return fmt.Errorf("failed to exec sql: %s", err)
+	}
+
+	return tx.Commit()
+}
+
+func (s *Seeder) loadDataFromCsv(tx *sql.Tx, table, filePath string) (sql.Result, error) {
+	query := `
+		LOAD DATA
+			LOCAL INFILE '%s'
+		INTO TABLE %s
+		FIELDS
+			TERMINATED BY ','
+		LINES
+			TERMINATED BY '\n'
+			IGNORE 1 LINES
+	`
+
+	mysql.RegisterLocalFile(filePath)
+
+	return tx.Exec(fmt.Sprintf(query, filePath, table))
+}

--- a/usecase/fetchlgtmimages/testdata/lgtm_images.csv
+++ b/usecase/fetchlgtmimages/testdata/lgtm_images.csv
@@ -1,0 +1,16 @@
+id,filename,path
+1,filename1,2022/02/02/01
+2,filename2,2022/02/02/02
+3,filename3,2022/02/02/03
+4,filename4,2022/02/02/04
+5,filename5,2022/02/02/05
+6,filename6,2022/02/02/06
+7,filename7,2022/02/02/07
+8,filename8,2022/02/02/08
+9,filename9,2022/02/02/09
+10,filename10,2022/02/02/10
+11,filename11,2022/02/02/11
+12,filename12,2022/02/02/12
+13,filename13,2022/02/02/13
+14,filename14,2022/02/02/14
+15,filename15,2022/02/02/15


### PR DESCRIPTION
# issueURL
#35 

# Doneの定義
- DBに接続するテストケースの方針が決まっていること
- usecase fetchlgtmimages RetrieveRecentlyCreatedImages() のDBに接続するテストケーが追加されていること

# 変更点概要
usecase fetchlgtmimages RetrieveRecentlyCreatedImages() のDBに接続するテストケースを追加。
テストケースは、下記のリポジトリを参考にした。
https://github.com/nekochans/portfolio-backend

また、ローカル開発用のDocker環境の構築が未対応のため、下記のリポジトリでMySQLのコンテナを起動しテスト用のDBとして利用する方針としている。
https://github.com/nekochans/lgtm-cat-migration

# レビュアーに重点的にチェックして欲しい点
テスト用のDBについて、上記の方針で進める形で良いか確認してもらえると🙏

# 補足情報
他のusecaseのテストは、別のPRで対応する。
テスト用DBの方針が決まったら、READMEも更新する想定。