### PR TITLE
usecase fetchlgtmimages.ExtractRandomImages() のDBに接続するテストケースを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,27 @@ AWS Lambda + Goで実装しています。
 
 このプロジェクトで利用しているプロファイル名は `lgtm-cat` です。
 
+### テスト
+
+一部のテストでDBに接続するテストをしています。
+
+DBに接続できないとエラーとなるので、テストの実行前に下記の設定を行ってください。
+
+#### MySQL コンテナの起動
+下記のリポジトリの docker-compose を利用してテスト用に MySQL のコンテナを起動。
+
+https://github.com/nekochans/lgtm-cat-migration
+
+#### 環境変数の設定
+環境変数を設定してください。
+
+```
+export TEST_DB_HOST=localhost:3306
+export TEST_DB_USER=local_lgtm_cat_user
+export TEST_DB_PASSWORD=password
+export TEST_DB_NAME=local_lgtm_cat
+```
+
 ### デプロイ
 ローカルからデプロイする場合、下記のコマンドを実行してください。
 


### PR DESCRIPTION
# issueURL
#35 

# 関連URL
同じIssueの別のPR
https://github.com/nekochans/lgtm-cat-api/pull/38

# Doneの定義
- usecase fetchlgtmimages.ExtractRandomImages() のDBに接続するテストケースが追加されること
- テストの実行方法がわかるようにドキュメントに記載されていること

# 変更点概要
- https://github.com/nekochans/lgtm-cat-api/pull/38 で決定したテスト方針に合わせて usecase fetchlgtmimages.ExtractRandomImages() のDBに接続するテストケースを追加
- テストを追加したのでテスト実行方法について README.md に追記

# 補足
テストデータとしてCSV ファイルのデータを MySQL にインポートできるように下記で MySQL の設定を変更
https://github.com/nekochans/lgtm-cat-migration/pull/9