### PR TITLE
CIでunit testを実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nekochans/lgtm-cat-migration
-          ref: feature/add-docer-compose-for-ci
           path: lgtm-cat-migration
       - name: docker-compose up
         working-directory: ./lgtm-cat-migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         working-directory: ./lgtm-cat-migration
         run: docker-compose up --build -d
       - name: migration up
+        working-directory: ./lgtm-cat-migration
         run: |
           sleep 20
           docker-compose exec -T migrate ./migrate_up.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nekochans/lgtm-cat-migration
-          ref: feature/change-copy
           path: lgtm-cat-migration
       - name: docker-compose up
         working-directory: ./lgtm-cat-migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
       - name: docker-compose up
         working-directory: ./lgtm-cat-migration
         run: docker-compose up --build -d
+      - name: migration up
+        run: |
+          sleep 20
+          docker-compose exec -T migrate ./migrate_up.sh
       - name: install dependencies
         run: |
           go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nekochans/lgtm-cat-migration
+          ref: feature/add-docer-compose-for-ci
           path: lgtm-cat-migration
       - name: docker-compose up
         working-directory: ./lgtm-cat-migration
-        run: docker-compose up --build -d
+        run: docker-compose -f docker-compose-ci.yml up --build -d
       - name: migration up
         working-directory: ./lgtm-cat-migration
         run: |
@@ -60,4 +61,4 @@ jobs:
           go mod download
       - name: run unit tests
         run: |
-          go test -v ./usecase/fetchlgtmimages
+          go test -v  $(go list ./... | grep -v /lgtm-cat-migration/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: nekochans/lgtm-cat-migration
+          ref: feature/change-copy
           path: lgtm-cat-migration
       - name: docker-compose up
         working-directory: ./lgtm-cat-migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
           go mod download
       - name: run unit tests
         run: |
-          go test -v ./usecase/createltgmimage
+          go test -v ./usecase/fetchlgtmimages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
 permissions:
   contents: read
 
+env:
+  DB_USERNAME: ${{ secrets.DB_USERNAME }}
+  DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+  DB_NAME: ${{ secrets.DB_NAME }}
+  DB_HOSTNAME: ${{ secrets.DB_HOSTNAME }}
+  TEST_DB_USER: ${{ secrets.DB_USERNAME }}
+  TEST_DB_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
+  TEST_DB_NAME: ${{ secrets.TEST_DB_NAME }}
+  TEST_DB_HOST: ${{ secrets.TEST_DB_HOST }}
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,16 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
-      - uses: actions/checkout@v2
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: checkout migration repo
+        uses: actions/checkout@v3
+        with:
+          repository: nekochans/lgtm-cat-migration
+          path: lgtm-cat-migration
+      - name: docker-compose up
+        working-directory: ./lgtm-cat-migration
+        run: docker-compose up --build -d
       - name: install dependencies
         run: |
           go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,18 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.44.2
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          go mod download
+      - name: run unit tests
+        run: |
+          go test -v ./usecase/createltgmimage

--- a/usecase/fetchlgtmimages/usecase_test.go
+++ b/usecase/fetchlgtmimages/usecase_test.go
@@ -224,7 +224,6 @@ func TestExtractRandomImagesConnectToDb(t *testing.T) {
 
 		// ランダムに抽出するので型のみテストする
 		for _, v := range res {
-			fmt.Println(v)
 			_, ok := interface{}(v).(domain.LgtmImage)
 			if !ok {
 				t.Fatalf("\nwant\n%T\ngot\n%T", v, domain.LgtmImage{})


### PR DESCRIPTION
# issueURL
#5 

# 関連URL
https://github.com/nekochans/lgtm-cat-api/pull/41

# Doneの定義
- CI で unit test が実行されること

# 変更点概要
GitHub Actions の CI に unit test の実行を追加。

## テスト用のDBについて
テスト用の DB は、 lgtm-cat-migration のリポジトリをチェックアウトし MySQL のコンテナを起動する方法とした。
この際、Docker で volume をマウントしていることによってエラーが発生したため、マウントしない方法でエラーを回避した。具体的には、下記の PR で CI 用の docker-compose-ci.yml を作成し、docker-compose up する際にこのファイルを指定している。

https://github.com/nekochans/lgtm-cat-migration/pull/12

エラーの内容の詳細は下記に記載しています。

### エラー内容
`go test -v $(go list ./... | grep -v /lgtm-cat-migration/)`を実行した際に、下記のエラーが発生しテストを実行することができなかった。
```
pattern ./...: open /home/runner/work/lgtm-cat-api/lgtm-cat-api/lgtm-cat-migration/data/#innodb_temp: permission denied
```
`docker-compose.yml`でvloumeを設定しているので、マウントした際に当該のディレクトリがない場合に自動的にディレクトリが作成される。この時、`./data`のユーザーが `systemd-coredump`になってしまっていることが原因だと考えられる。

<img width="573" alt="スクリーンショット 2022-04-24 21 05 59" src="https://user-images.githubusercontent.com/32682645/164975606-e8fa3e55-1576-45c8-a095-11856c11c396.png">

GitHub Actionsの実行内容：https://github.com/nekochans/lgtm-cat-api/runs/6140448508?check_suite_focus=true

### エラー回避のために試したこと
permission denied 回避のために下記を試したが、エラーを解消することができなかった。

- 事前に`./data`ディレクトリを事前に作成しておく 
-> docker-compose up をした時点で、ユーザーが `systemd-coredump`になってしまった

- docker-compose up した後に、ユーザーを変更する
-> ユーザーの変更は可能だが、テスト実行時に下記のエラーが発生した
```
error: Error 1030: Got error 168 - 'Unknown (generic) error from engine' from storage engine in line 0: CREATE TABLE `schema_migrations` (version bigint not null primary key, dirty boolean not null)
```
- テスト対象のファイルを`go list ./...` で取得するのではなく、`go test -v ./usecase/...`を使用する
-> 現状は、usecaseのみテストがある状態なのでパッケージを指定してしまっても問題なさそうだったが、今後テストが増えた時に追加分のテストがCIで実行されないという事象が発生しそうだったのでやめた
-> `./lgtm-api-migration` のディレクトリはテスト対象から除外するという方法ができれば良いが、わからなかった


# レビュアーに重点的にチェックして欲しい点
テスト用の DB のエラーの回避のために volume しないように対応したが、他にいい対応方法があれば教えてもらえると🙏

# 補足情報
カバレッジ計測については、別のPRで対応予定。