### PR TITLE
CIにカバレッジ計測を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,6 @@ jobs:
         run: |
           go mod download
       - name: run unit tests
-        run: |
-          go test -v  $(go list ./... | grep -v /lgtm-cat-migration/)
+        run: go test -v  $(go list ./... | grep -v /lgtm-cat-migration/)
+      - name: run go mod tidy
+        run: go mod tidy && git diff -s --exit-code go.sum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           go mod download
       - name: run unit tests
-        run: go test -v  $(go list ./... | grep -v /lgtm-cat-migration/)
+        run: go test -v -race -coverprofile coverage.out -covermode atomic $(go list ./... | grep -v /lgtm-cat-migration/)
+      - name: upload coverage to Codecov
+        uses: codecov/codecov-action@v2
       - name: run go mod tidy
         run: go mod tidy && git diff -s --exit-code go.sum

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # lgtm-cat-api
+[![ci](https://github.com/nekochans/lgtm-cat-api/actions/workflows/ci.yml/badge.svg)](https://github.com/nekochans/lgtm-cat-api/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nekochans/lgtm-cat-api/branch/main/graph/badge.svg?token=BCZABFS4P0)](https://codecov.io/gh/nekochans/lgtm-cat-api)
+
 LGTMeowで利用するWebAPI
 
 ## Getting Started


### PR DESCRIPTION
# issueURL
#5 

# 関連URL
https://github.com/nekochans/lgtm-cat-api/pull/41
https://github.com/nekochans/lgtm-cat-api/pull/43

# Doneの定義
CIでカバレッジ計測ができること

# 変更点概要
- CI に go mod tidy コマンドが実行済かどうかの確認を追加
- CI にカバレッジ計測とCodecovへのアップロードを追加
    - カバレッジ計測サービスには [Codecov](https://about.codecov.io/)を利用
- README に Codecov と CI のステータスバッチを追加　

# 補足情報
PullRequest にコメントするように設定しているが、コメントをオフにすることも可能。
運用してみてコメントが必要ないと思った場合に変更しようと思う。
https://docs.codecov.com/docs/pull-request-comments

このPRで、#5 の対応は完了となる。