### PR TITLE
http: superfluous response.WriteHeader call が表示されないように WriteHeader の実行順を変更

### DIFF
--- a/handler/create_lgtm_image.go
+++ b/handler/create_lgtm_image.go
@@ -54,9 +54,9 @@ func (h *createLgtmImageHandler) Create(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
 	response := &CreateLgtmImageResponse{ImageUrl: image.Url}
 	responseJson, _ := json.Marshal(response)
 	fmt.Fprint(w, string(responseJson))
-	w.WriteHeader(http.StatusAccepted)
-	w.Header().Add("Content-Type", "application/json")
 }

--- a/handler/fetch_lgtm_images.go
+++ b/handler/fetch_lgtm_images.go
@@ -36,11 +36,11 @@ func (h *fetchImagesHandler) Extract(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	response := &ExtractRandomImagesResponse{LgtmImages: lgtmImages}
 	responseJson, _ := json.Marshal(response)
 	fmt.Fprint(w, string(responseJson))
-	w.WriteHeader(http.StatusOK)
-	w.Header().Add("Content-Type", "application/json")
 }
 
 func (h *fetchImagesHandler) RetrieveRecentlyCreated(w http.ResponseWriter, r *http.Request) {
@@ -51,9 +51,9 @@ func (h *fetchImagesHandler) RetrieveRecentlyCreated(w http.ResponseWriter, r *h
 		return
 	}
 
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	response := &RetrieveRecentlyCreatedImagesResponse{LgtmImages: lgtmImages}
 	responseJson, _ := json.Marshal(response)
 	fmt.Fprint(w, string(responseJson))
-	w.WriteHeader(http.StatusOK)
-	w.Header().Add("Content-Type", "application/json")
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/51

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/51 の完了の定義が満たされていること

# 変更点概要
HTTP レスポンスの WriteHeader の後に Write が実行されるように変更。