### PR TITLE
Error インターフェースを満たす Error 型として振る舞う型の名前は接尾語にErrorをつけるように変更

### DIFF
--- a/domain/create_lgtm_image.go
+++ b/domain/create_lgtm_image.go
@@ -11,27 +11,27 @@ var (
 	ErrInvalidImageExtension = errors.New("invalid image extension")
 )
 
-type ErrDecodeImage struct {
+type DecodeImageError struct {
 	Err error
 }
 
-func (e *ErrDecodeImage) Error() string {
+func (e *DecodeImageError) Error() string {
 	return fmt.Sprintf("failed to decode Base64 image, %s", e.Err)
 }
 
-type ErrGenerateImageName struct {
+type GenerateImageNameError struct {
 	Err error
 }
 
-func (e *ErrGenerateImageName) Error() string {
+func (e *GenerateImageNameError) Error() string {
 	return fmt.Sprintf("failed to generate image name, %s", e.Err)
 }
 
-type ErrTimeLoadLocation struct {
+type TimeLoadLocationError struct {
 	Err error
 }
 
-func (e *ErrTimeLoadLocation) Error() string {
+func (e *TimeLoadLocationError) Error() string {
 	return fmt.Sprintf("failed to Time LoadLocation, %s", e.Err)
 }
 

--- a/usecase/createltgmimage/usecase.go
+++ b/usecase/createltgmimage/usecase.go
@@ -37,7 +37,7 @@ func (u *UseCase) CreateLgtmImage(ctx context.Context, reqBody RequestBody) (*do
 
 	decodedImg, err := base64.StdEncoding.DecodeString(reqBody.Image)
 	if err != nil {
-		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.ErrDecodeImage{Err: err})
+		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.DecodeImageError{Err: err})
 	}
 
 	buffer := new(bytes.Buffer)
@@ -45,12 +45,12 @@ func (u *UseCase) CreateLgtmImage(ctx context.Context, reqBody RequestBody) (*do
 
 	prefix, err := domain.BuildS3Prefix(time.Now().UTC())
 	if err != nil {
-		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.ErrTimeLoadLocation{Err: err})
+		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.TimeLoadLocationError{Err: err})
 	}
 
 	imageName, err := domain.GenerateImageName(u.idGenerator)
 	if err != nil {
-		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.ErrGenerateImageName{Err: err})
+		return nil, fmt.Errorf("faild to crete LGTM image: %w", &domain.GenerateImageNameError{Err: err})
 	}
 
 	uploadS3param := domain.CreateUploadS3param(

--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -131,7 +131,7 @@ func TestCreateLgtmImage(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
 		}
-		var want *domain.ErrGenerateImageName
+		var want *domain.GenerateImageNameError
 		if !errors.As(err, &want) {
 			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
 		}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/53

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/53 の完了条件を満たしていること

# 変更点概要
Error インターフェースを満たす Error 型として振る舞う型の名前は接尾語にErrorをつけるように変更。
エラーの変数は Err から変数名が始まるようになっていたので、対応不要であった。

# 補足
CI codecov/patch で失敗しているが、全体のカバレッジには変化がないのでテストケースは修正しない方針としたい。
この点について意見もらえると🙏