### PR TITLE
panicが発生した際に500 Internal Server Errorを返すミドルウェアを追加

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/nekochans/lgtm-cat-api/infrastructure"
@@ -38,7 +39,14 @@ func recovery(next http.Handler) http.Handler {
 				if rvr == http.ErrAbortHandler {
 					panic(rvr)
 				}
-				RenderErrorResponse(w, InternalServerError)
+
+				err, ok := rvr.(error)
+				if !ok {
+					err = fmt.Errorf("panic recover: %v", rvr)
+				}
+
+				logger := extractLogger(r.Context())
+				logger.Error(err)
 			}
 		}()
 		next.ServeHTTP(w, r)

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -30,3 +30,18 @@ func withLogger(logger infrastructure.Logger) func(next http.Handler) http.Handl
 func extractLogger(ctx context.Context) infrastructure.Logger {
 	return ctx.Value(logKey).(infrastructure.Logger)
 }
+
+func recovery(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rvr := recover(); rvr != nil {
+				if rvr == http.ErrAbortHandler {
+					panic(rvr)
+				}
+				RenderErrorResponse(w, InternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}

--- a/handler/router.go
+++ b/handler/router.go
@@ -34,6 +34,7 @@ func NewRouter(uploader *manager.Uploader, q *db.Queries, logger infrastructure.
 		AllowCredentials: true,
 	}))
 	r.Use(withLogger(logger))
+	r.Use(recovery)
 
 	r.Post("/lgtm-images", createLgtmImageHandler.Create)
 	r.Get("/lgtm-images", extractRandomImagesHandler.Extract)


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/60

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/60 の完了条件が満たされていること

# 変更点概要
panicが発生した際に500 Internal Server Errorを返すミドルウェアを追加。

レスポンス
```
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json
< Vary: Origin
< Date: Mon, 02 Jan 2023 01:26:25 GMT
< Content-Length: 35
<
{ [35 bytes data]
100    35  100    35    0     0    755      0 --:--:-- --:--:-- --:--:--   921
* Connection #0 to host localhost left intact
{
  "message": "Internal Server Error"
}
```

# 補足情報
O’Reilly 実用Go言語』(p.246 10.5.3 ハンドラー内部でのpanicの防御)を参考にした。
