### PR TITLE
Go 1.19 にバージョンアップ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           go mod download
       - name: run unit tests
-        run: go test -v -race -coverprofile coverage.out -covermode atomic $(go list ./... | grep -v /lgtm-cat-migration/)
+        run: go test -shuffle=on -v -race -coverprofile coverage.out -covermode atomic $(go list ./... | grep -v /lgtm-cat-migration/)
       - name: upload coverage to Codecov
         uses: codecov/codecov-action@v2
       - name: run go mod tidy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.19'
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.19'
       - name: checkout
         uses: actions/checkout@v3
       - name: checkout migration repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.44.2
+          version: v1.50.1
   test:
     name: test
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.3
 
-FROM golang:1.16-alpine3.15 as base
+FROM golang:1.19-alpine3.15 as base
 LABEL maintainer="https://github.com/nekochans"
 WORKDIR /go/app
 ENV CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ sqlc-generate:
 
 .PHONY: lint
 lint:
-	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run -v
+	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.50.1 golangci-lint run -v
 
 .PHONY: format
 format:
-	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.44.2 golangci-lint run -v --fix
+	docker run --rm -v `pwd`:/app -w /app golangci/golangci-lint:v1.50.1 golangci-lint run -v --fix
 
 .PHONY: run-normal-build
 run-normal-build:

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	_ "github.com/go-sql-driver/mysql"
@@ -21,7 +22,14 @@ func main() {
 	logger = infrastructure.NewLogger()
 
 	r := handler.NewRouter(uploader, queries, logger)
-	err := http.ListenAndServe(":3333", r)
+
+	const timeoutSecond = 10
+	server := &http.Server{
+		Addr:              ":3333",
+		Handler:           r,
+		ReadHeaderTimeout: timeoutSecond * time.Second,
+	}
+	err := server.ListenAndServe()
 	if err != nil {
 		log.Println(err)
 		return

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       target: unit-test
     volumes:
       - ./:/go/app
-    command: go test -v ./...
+    command: go test -shuffle=on -v ./...
     environment:
       TEST_DB_HOST: ${TEST_DB_HOST}
       TEST_DB_USER: ${TEST_DB_USER}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nekochans/lgtm-cat-api
 
-go 1.16
+go 1.19
 
 require (
 	github.com/aws/aws-lambda-go v1.24.0
@@ -15,4 +15,19 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	go.uber.org/zap v1.17.0
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/credentials v1.2.1 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.1.1 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.1.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.1.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.4.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.2.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.4.1 // indirect
+	github.com/aws/smithy-go v1.4.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
 )

--- a/usecase/fetchlgtmimages/usecase_test.go
+++ b/usecase/fetchlgtmimages/usecase_test.go
@@ -40,8 +40,6 @@ var cdnDomain = "lgtm-images.lgtmeow.com"
 
 var testDb *sql.DB
 
-// Go1.15 から TestMain には os.Exit() のコールが不要になったのでlintのルールを無効化
-//nolint:staticcheck
 func TestMain(m *testing.M) {
 	dbCreator := &test.DbCreator{}
 	var err error


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/39

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/39 の完了条件を満たしていること

# 変更点概要
* Go 1.19 にバージョンアップ
* Go のバージョンアップにより https://github.com/golangci/golangci-lint/issues/2374 の影響で golangci-lint がエラーになったので、golangci-lint も最新バージョンにアップデート
  *  バージョンアップによりエラーが追加されたので対応
  * [golangci-lint で指摘されたエラーを回避するために ReadHeaderTimeout を設定](https://github.com/nekochans/lgtm-cat-api/pull/64/commits/6a46ca225b3d733f8f9d77359c60c5cd6ae129ec)
  * タイムアウトの時間は、Lambda 自体のタイムアウトが29秒となっており、それより短い時間の10秒を適当に指定
  * 参考：https://christina04.hatenablog.com/entry/server-request-timeout

また、Issueとは関係がないが下記の変更を行なった。
*  Go 1.17 よりテスト実行時に shuffle オプションを指定できるようになったので、テスト時にオプションを指定するように変更
    * このオプションを指定することでテストがランダムに実行され、前に書いたテストの実行結果に依存する状態を検知し、回避することが可能となる
    * 詳細については、下記の参考記事を参照
      * [Go 1.17のtesting新機能 | フューチャー技術ブログ shuffleオプションについて](https://future-architect.github.io/articles/20210812a/#shuffle%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
      * O’Reilly 実用Go言語』(p.302 13.6.2 テストの順序依存の排除)

# 補足
https://github.com/nekochans/lgtm-cat-api/issues/9 はこのPRで対応不要となるので対応無しでクローズする予定。