### PR TITLE
エラーを返す処理が間違って消えていたので追加

### DIFF
--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -47,6 +47,8 @@ func recovery(next http.Handler) http.Handler {
 
 				logger := extractLogger(r.Context())
 				logger.Error(err)
+
+				RenderErrorResponse(w, InternalServerError)
 			}
 		}()
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/60

# 関連URL
https://github.com/nekochans/lgtm-cat-api/pull/61

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/60 の完了条件が満たされていること

# 変更点概要
https://github.com/nekochans/lgtm-cat-api/pull/61/commits/fe4c61f3396f80d3bcbb60357b9f74b70a0de339#diff-0b46d7cd26aa441d6e866b658afb5a9d61e9ff5f728d1524b62dcbf4b1309775R41

この処理が次の commit で消えてしまっていたので修正。