### PR TITLE
net/http 内部のロガーを独自のロガーに変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 
 FROM base AS dev
 ARG AIR_VERSION=v1.40.2
-ARG DLV_VERSION=v1.8.3
+ARG DLV_VERSION=v1.20.1
 RUN --mount=target=. \
   --mount=type=cache,target=/root/.cache/go-build \
   set -eux && \

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 	err := server.ListenAndServe()
 	if err != nil {
-		log.Println(err)
+		logger.Error(err)
 		return
 	}
 }

--- a/cmd/local/main.go
+++ b/cmd/local/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"net/http"
 	"time"
@@ -28,10 +29,20 @@ func main() {
 		Addr:              ":3333",
 		Handler:           r,
 		ReadHeaderTimeout: timeoutSecond * time.Second,
+		ErrorLog:          log.New(&logForwarder{l: logger}, "", 0),
 	}
 	err := server.ListenAndServe()
 	if err != nil {
 		log.Println(err)
 		return
 	}
+}
+
+type logForwarder struct {
+	l infrastructure.Logger
+}
+
+func (fw *logForwarder) Write(p []byte) (int, error) {
+	fw.l.Error(errors.New(string(p)))
+	return len(p), nil
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/66

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/66 の完了条件が満たされていること

# 変更点概要
http.Server に独自のロギングを設定し、net/http パッケージ内部で出力されるログがJSON形式で出力されるように変更。

また、https://github.com/nekochans/lgtm-cat-api/pull/64 の対応で Go 1.19 に変更したことにより go-delve/delve でエラーとなったので、go-delve/delve を最新バージョンにアップグレード。

# 補足情報
『O’Reilly 実用Go言語』(p.286 net/httpのエラーログをカスタマイズ) を参考にした。