### PR TITLE
エラーの設計を見直し

### DIFF
--- a/derrors/derrors.go
+++ b/derrors/derrors.go
@@ -1,0 +1,9 @@
+package derrors
+
+import "fmt"
+
+func Wrap(errp *error, format string, args ...any) {
+	if *errp != nil {
+		*errp = fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), *errp)
+	}
+}

--- a/domain/create_lgtm_image.go
+++ b/domain/create_lgtm_image.go
@@ -3,37 +3,14 @@ package domain
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"time"
+
+	"github.com/nekochans/lgtm-cat-api/derrors"
 )
 
 var (
 	ErrInvalidImageExtension = errors.New("invalid image extension")
 )
-
-type DecodeImageError struct {
-	Err error
-}
-
-func (e *DecodeImageError) Error() string {
-	return fmt.Sprintf("failed to decode Base64 image, %s", e.Err)
-}
-
-type GenerateImageNameError struct {
-	Err error
-}
-
-func (e *GenerateImageNameError) Error() string {
-	return fmt.Sprintf("failed to generate image name, %s", e.Err)
-}
-
-type TimeLoadLocationError struct {
-	Err error
-}
-
-func (e *TimeLoadLocationError) Error() string {
-	return fmt.Sprintf("failed to Time LoadLocation, %s", e.Err)
-}
 
 type UploadedLgtmImage struct {
 	Url string
@@ -62,11 +39,15 @@ func CanConvertImageExtension(ext string) bool {
 	return true
 }
 
-func GenerateImageName(u UniqueIdGenerator) (string, error) {
+func GenerateImageName(u UniqueIdGenerator) (imageName string, err error) {
+	defer derrors.Wrap(&err, "GenerateImageName()")
+
 	return u.Generate()
 }
 
-func BuildS3Prefix(t time.Time) (string, error) {
+func BuildS3Prefix(t time.Time) (prefix string, err error) {
+	defer derrors.Wrap(&err, "BuildS3Prefix(%+v)", t)
+
 	tokyo, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		return "", err

--- a/domain/lgtm_image_repository.go
+++ b/domain/lgtm_image_repository.go
@@ -2,20 +2,10 @@ package domain
 
 import (
 	"context"
-	"fmt"
 )
 
 type LgtmImageRepository interface {
 	FindAllIds(context.Context) (allIds []int32, err error)
 	FindByIds(context.Context, []int32) (lgtmImageObjects []LgtmImageObject, err error)
 	FindRecentlyCreated(context.Context, int) (lgtmImageObjects []LgtmImageObject, err error)
-}
-
-type LgtmImageError struct {
-	Op  string
-	Err error
-}
-
-func (e *LgtmImageError) Error() string {
-	return fmt.Sprintf("lgtmImageRepository: %s, %s", e.Op, e.Err)
 }

--- a/domain/lgtm_image_repository.go
+++ b/domain/lgtm_image_repository.go
@@ -8,7 +8,7 @@ import (
 type LgtmImageRepository interface {
 	FindAllIds(context.Context) (allIds []int32, err error)
 	FindByIds(context.Context, []int32) (lgtmImageObjects []LgtmImageObject, err error)
-	FindRecentlyCreated(context.Context, int) ([]LgtmImageObject, error)
+	FindRecentlyCreated(context.Context, int) (lgtmImageObjects []LgtmImageObject, err error)
 }
 
 type LgtmImageError struct {

--- a/domain/lgtm_image_repository.go
+++ b/domain/lgtm_image_repository.go
@@ -6,8 +6,8 @@ import (
 )
 
 type LgtmImageRepository interface {
-	FindAllIds(context.Context) ([]int32, error)
-	FindByIds(context.Context, []int32) ([]LgtmImageObject, error)
+	FindAllIds(context.Context) (allIds []int32, err error)
+	FindByIds(context.Context, []int32) (lgtmImageObjects []LgtmImageObject, err error)
 	FindRecentlyCreated(context.Context, int) ([]LgtmImageObject, error)
 }
 

--- a/domain/s3_repository.go
+++ b/domain/s3_repository.go
@@ -2,18 +2,8 @@ package domain
 
 import (
 	"context"
-	"fmt"
 )
 
 type S3Repository interface {
-	Upload(context.Context, *UploadS3param) error
-}
-
-type S3Error struct {
-	Op  string
-	Err error
-}
-
-func (e *S3Error) Error() string {
-	return fmt.Sprintf("s3Repository: %s, %s", e.Op, e.Err)
+	Upload(context.Context, *UploadS3param) (err error)
 }

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -67,16 +67,18 @@ func (r *lgtmImageRepository) FindByIds(
 	return lgtmImage, nil
 }
 
-func (r *lgtmImageRepository) FindRecentlyCreated(c context.Context, count int) ([]domain.LgtmImageObject, error) {
+func (r *lgtmImageRepository) FindRecentlyCreated(
+	c context.Context,
+	count int,
+) (lgtmImageObjects []domain.LgtmImageObject, err error) {
+	defer derrors.Wrap(&err, "lgtmImageRepository.FindRecentlyCreated(%v)", count)
+
 	ctx, cancel := context.WithTimeout(c, dbTimeoutSecond*time.Second)
 	defer cancel()
 
 	rows, err := r.db.ListRecentlyCreatedLgtmImages(ctx, int32(count))
 	if err != nil {
-		return nil, &domain.LgtmImageError{
-			Op:  "FindRecentlyCreated",
-			Err: err,
-		}
+		return nil, err
 	}
 
 	var lgtmImage []domain.LgtmImageObject

--- a/infrastructure/lgtm_image_repository.go
+++ b/infrastructure/lgtm_image_repository.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	db "github.com/nekochans/lgtm-cat-api/db/sqlc"
+	"github.com/nekochans/lgtm-cat-api/derrors"
 	"github.com/nekochans/lgtm-cat-api/domain"
 )
 
@@ -18,22 +19,26 @@ func NewLgtmImageRepository(db *db.Queries) *lgtmImageRepository {
 	return &lgtmImageRepository{db: db}
 }
 
-func (r *lgtmImageRepository) FindAllIds(c context.Context) ([]int32, error) {
+func (r *lgtmImageRepository) FindAllIds(c context.Context) (allIds []int32, err error) {
+	defer derrors.Wrap(&err, "lgtmImageRepository.FindAllIds()")
+
 	ctx, cancel := context.WithTimeout(c, dbTimeoutSecond*time.Second)
 	defer cancel()
 
 	ids, err := r.db.ListLgtmImageIds(ctx)
 	if err != nil {
-		return nil, &domain.LgtmImageError{
-			Op:  "FindAllIds",
-			Err: err,
-		}
+		return nil, err
 	}
 
 	return ids, nil
 }
 
-func (r *lgtmImageRepository) FindByIds(c context.Context, ids []int32) ([]domain.LgtmImageObject, error) {
+func (r *lgtmImageRepository) FindByIds(
+	c context.Context,
+	ids []int32,
+) (lgtmImageObjects []domain.LgtmImageObject, err error) {
+	defer derrors.Wrap(&err, "lgtmImageRepository.FindByIds(%v)", ids)
+
 	ctx, cancel := context.WithTimeout(c, dbTimeoutSecond*time.Second)
 	defer cancel()
 
@@ -51,10 +56,7 @@ func (r *lgtmImageRepository) FindByIds(c context.Context, ids []int32) ([]domai
 
 	rows, err := r.db.ListLgtmImages(ctx, listLgtmImagesParams)
 	if err != nil {
-		return nil, &domain.LgtmImageError{
-			Op:  "FindByIds",
-			Err: err,
-		}
+		return nil, err
 	}
 
 	var lgtmImage []domain.LgtmImageObject

--- a/infrastructure/s3_repository.go
+++ b/infrastructure/s3_repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/nekochans/lgtm-cat-api/derrors"
 	"github.com/nekochans/lgtm-cat-api/domain"
 )
 
@@ -31,7 +32,9 @@ func decideS3ContentType(ext string) string {
 
 	return contentType
 }
-func (r *s3Repository) Upload(c context.Context, param *domain.UploadS3param) error {
+func (r *s3Repository) Upload(c context.Context, param *domain.UploadS3param) (err error) {
+	defer derrors.Wrap(&err, "s3Repository.Upload(%+v)", param)
+
 	const s3timeoutSecond = 10
 	ctx, cancel := context.WithTimeout(c, s3timeoutSecond*time.Second)
 	defer cancel()
@@ -43,12 +46,9 @@ func (r *s3Repository) Upload(c context.Context, param *domain.UploadS3param) er
 		Key:         aws.String(param.Key),
 	}
 
-	_, err := r.uploader.Upload(ctx, input)
+	_, err = r.uploader.Upload(ctx, input)
 	if err != nil {
-		return &domain.S3Error{
-			Op:  "Upload",
-			Err: err,
-		}
+		return err
 	}
 
 	return nil

--- a/infrastructure/unique_id_generator.go
+++ b/infrastructure/unique_id_generator.go
@@ -2,11 +2,14 @@ package infrastructure
 
 import (
 	"github.com/google/uuid"
+	"github.com/nekochans/lgtm-cat-api/derrors"
 )
 
 type UuidGenerator struct{}
 
-func (g *UuidGenerator) Generate() (string, error) {
+func (g *UuidGenerator) Generate() (id string, err error) {
+	defer derrors.Wrap(&err, "UuidGenerator.Generate()")
+
 	uid, err := uuid.NewRandom()
 	if err != nil {
 		return "", err

--- a/usecase/createltgmimage/usecase_test.go
+++ b/usecase/createltgmimage/usecase_test.go
@@ -132,19 +132,12 @@ func TestCreateLgtmImage(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
 		}
-		var want *domain.GenerateImageNameError
-		if !errors.As(err, &want) {
-			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
-		}
 	})
 
 	t.Run("Failure upload image to s3", func(t *testing.T) {
 		s3Mock := &mockS3Repository{
 			FakeUpload: func(context.Context, *domain.UploadS3param) error {
-				return &domain.S3Error{
-					Op:  "Upload",
-					Err: errors.New("s3 upload dummy error"),
-				}
+				return errors.New("s3 upload dummy error")
 			},
 		}
 		idGenMock := &mockUniqueIdGenerator{
@@ -167,10 +160,6 @@ func TestCreateLgtmImage(t *testing.T) {
 		_, err := u.CreateLgtmImage(ctx, *r)
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
-		}
-		var want *domain.S3Error
-		if !errors.As(err, &want) {
-			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
 		}
 	})
 }

--- a/usecase/fetchlgtmimages/usecase.go
+++ b/usecase/fetchlgtmimages/usecase.go
@@ -2,7 +2,6 @@ package fetchlgtmimages
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -75,10 +74,12 @@ func (u *UseCase) ExtractRandomImages(ctx context.Context) (randomImages []domai
 	return lgtmImages, nil
 }
 
-func (u *UseCase) RetrieveRecentlyCreatedImages(ctx context.Context) ([]domain.LgtmImage, error) {
+func (u *UseCase) RetrieveRecentlyCreatedImages(ctx context.Context) (recentlyImages []domain.LgtmImage, err error) {
+	defer derrors.Wrap(&err, "UseCase.RetrieveRecentlyCreatedImages()")
+
 	rows, err := u.repository.FindRecentlyCreated(ctx, domain.FetchLgtmImageCount)
 	if err != nil {
-		return nil, fmt.Errorf("faild to retrieve recently created images: %w", err)
+		return nil, err
 	}
 
 	var lgtmImages []domain.LgtmImage

--- a/usecase/fetchlgtmimages/usecase.go
+++ b/usecase/fetchlgtmimages/usecase.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/nekochans/lgtm-cat-api/derrors"
 	"github.com/nekochans/lgtm-cat-api/domain"
 )
 
@@ -47,10 +48,12 @@ func pickupRandomIdsNoDuplicates(ids []int32, listCount int) []int32 {
 	return randomIds
 }
 
-func (u *UseCase) ExtractRandomImages(ctx context.Context) ([]domain.LgtmImage, error) {
+func (u *UseCase) ExtractRandomImages(ctx context.Context) (randomImages []domain.LgtmImage, err error) {
+	defer derrors.Wrap(&err, "UseCase.ExtractRandomImages()")
+
 	ids, err := u.repository.FindAllIds(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("faild to extract randam images: %w", err)
+		return nil, err
 	}
 	if len(ids) < domain.FetchLgtmImageCount {
 		return nil, domain.ErrRecordCount
@@ -60,7 +63,7 @@ func (u *UseCase) ExtractRandomImages(ctx context.Context) ([]domain.LgtmImage, 
 
 	rows, err := u.repository.FindByIds(ctx, randomIds)
 	if err != nil {
-		return nil, fmt.Errorf("faild to extract randam images: %w", err)
+		return nil, err
 	}
 
 	var lgtmImages []domain.LgtmImage

--- a/usecase/fetchlgtmimages/usecase_test.go
+++ b/usecase/fetchlgtmimages/usecase_test.go
@@ -256,10 +256,7 @@ func TestRetrieveRecentlyCreatedImages(t *testing.T) {
 	t.Run("Failure find recently created images", func(t *testing.T) {
 		mock := &mockLgtmImageRepository{
 			FakeFindRecentlyCreated: func(context.Context, int) ([]domain.LgtmImageObject, error) {
-				return nil, &domain.LgtmImageError{
-					Op:  "FindRecentlyCreated",
-					Err: errors.New("FindRecentlyCreated dummy error"),
-				}
+				return nil, errors.New("FindRecentlyCreated dummy error")
 			},
 		}
 		u := NewUseCase(mock, cdnDomain)
@@ -268,10 +265,6 @@ func TestRetrieveRecentlyCreatedImages(t *testing.T) {
 		_, err := u.RetrieveRecentlyCreatedImages(ctx)
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
-		}
-		var want *domain.LgtmImageError
-		if !errors.As(err, &want) {
-			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
 		}
 	})
 }

--- a/usecase/fetchlgtmimages/usecase_test.go
+++ b/usecase/fetchlgtmimages/usecase_test.go
@@ -138,10 +138,7 @@ func TestExtractRandomImages(t *testing.T) {
 	t.Run("Failure find all ids", func(t *testing.T) {
 		mock := &mockLgtmImageRepository{
 			FakeFindAllIds: func(context.Context) ([]int32, error) {
-				return nil, &domain.LgtmImageError{
-					Op:  "FindAllIds",
-					Err: errors.New("FindAllIds dummy error"),
-				}
+				return nil, errors.New("FindAllIds dummy error")
 			},
 			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
 				return nil, nil
@@ -155,13 +152,9 @@ func TestExtractRandomImages(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
 		}
-		var want *domain.LgtmImageError
-		if !errors.As(err, &want) {
-			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
-		}
 	})
 
-	t.Run("Failure find all ids", func(t *testing.T) {
+	t.Run("Failure find by ids", func(t *testing.T) {
 		var findAllIdsResponse []int32
 		for i := 1; i <= domain.FetchLgtmImageCount; i++ {
 			findAllIdsResponse = append(
@@ -175,10 +168,7 @@ func TestExtractRandomImages(t *testing.T) {
 				return findAllIdsResponse, nil
 			},
 			FakeFindByIds: func(context.Context, []int32) ([]domain.LgtmImageObject, error) {
-				return nil, &domain.LgtmImageError{
-					Op:  "FindByIds",
-					Err: errors.New("FindByIds dummy error"),
-				}
+				return nil, errors.New("FindByIds dummy error")
 			},
 		}
 
@@ -188,10 +178,6 @@ func TestExtractRandomImages(t *testing.T) {
 		_, err := u.ExtractRandomImages(ctx)
 		if err == nil {
 			t.Fatal("expected to return an error, but no error")
-		}
-		var want *domain.LgtmImageError
-		if !errors.As(err, &want) {
-			t.Errorf("\nwant\n%T\ngot\n%T", want, errors.Unwrap(err))
 		}
 	})
 }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/68

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/68 の完了の定義を満たしていること

# 変更点概要
[Goでスタイリッシュにエラーをラップする方法を学んだ - カミナシ エンジニアブログ](https://kaminashi-developer.hatenablog.jp/entry/2022/12/15/093000) を参考に、エラーをラップする関数を定義。既存のエラー箇所を、独自で定義したラップ関数を利用する構成に変更。

エラーログの出力内容は、下記のように変更され見やすくなった印象。
```
変更前: faild to extract randam images: lgtmImageRepository: FindAllIds, dial tcp: lookup mysql on 127.0.0.11:53: no such host
変更後: UseCase.ExtractRandomImages(): lgtmImageRepository.FindAllIds(): dial tcp: lookup mysql on 127.0.0.11:53: no such host
```

下記の repository のエラーを定義した構造体はログのエラーの発生箇所を特定するために定義したものであったが、今回の設計見直しによって意味がなくなったので削除した。
* https://github.com/nekochans/lgtm-cat-api/pull/69/files#diff-e9d469d0c26a5f08d773e0560faefb625743f9f69480422fe774c850b452e736L14
* https://github.com/nekochans/lgtm-cat-api/pull/69/files#diff-1c0e27db42c0cee0d568c1e8d8416e04ae116e36475050b157ca69e07ed05994L12

domain に定義していた下記の構造体についても、domain のエラーというより技術的なエラーであり、エラーの発生箇所を特定するために定義した意味合いの方が強かったので、こちらも削除している。
* https://github.com/nekochans/lgtm-cat-api/pull/69/files#diff-f61bce3b61baa8299a1ef8805b97c22ae9853e8ac4640b9236dabc6d8ba2d907L14-L36

# 補足
テストケースで `errors.As`を使用している箇所がなくなったため、テストケースを Table Driven Test に変更できそうである。Table Driven Test の方が可読性、保守性が高いと考えられるため テストケースを Table Driven Test に変更する。
修正範囲が大きくなりそうなため、別の Issue #70 で対応する予定。