### PR TITLE
CD に Sentry Release の追加

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -93,4 +93,4 @@ jobs:
           SENTRY_PROJECT: "lgtm-cat-api"
         with:
           environment: prod
-          version: ${{ github.ref }}
+          version: ${{ github.sha }}

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -36,7 +36,7 @@ jobs:
           ECR_REPOSITORY: prod-lgtm-cat-api-nginx
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --target production --platform amd64 --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
-          docker build --target production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
+          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -36,7 +36,7 @@ jobs:
           ECR_REPOSITORY: prod-lgtm-cat-api-nginx
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --target production --platform amd64 --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -83,3 +83,14 @@ jobs:
           wait-for-service-stability: true
           service: prod-lgtm-cat-api
           cluster: prod-lgtm-cat-api
+
+      - name: Create Sentry release
+        if: success()
+        uses: getsentry/action-release@v1.2.1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: "lgtm-cat-api"
+        with:
+          environment: prod
+          version: ${{ github.ref }}

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -49,7 +49,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
-          docker build --target production -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
+          docker build --target production --platform amd64 --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -93,4 +93,4 @@ jobs:
           SENTRY_PROJECT: "lgtm-cat-api"
         with:
           environment: stg
-          version: ${{ github.ref }}
+          version: ${{ github.sha }}

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -83,3 +83,14 @@ jobs:
           wait-for-service-stability: true
           service: stg-lgtm-cat-api
           cluster: stg-lgtm-cat-api
+
+      - name: Create Sentry release
+        if: success()
+        uses: getsentry/action-release@v1.2.1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: "lgtm-cat-api"
+        with:
+          environment: stg
+          version: ${{ github.ref }}

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -36,7 +36,7 @@ jobs:
           ECR_REPOSITORY: stg-lgtm-cat-api-nginx
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -49,7 +49,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
-          docker build --target production --platform amd64 --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG  -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,10 @@ RUN --mount=target=. \
   --mount=type=cache,target=/root/.cache/go-build
 
 FROM base AS build
+ARG COMMIT_HASH
 RUN --mount=target=. \
   --mount=type=cache,target=/root/.cache/go-build \
-  GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /out/lgtm-cat-api .
+  GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X main.release=${COMMIT_HASH} -s -w" -o /out/lgtm-cat-api .
 
 FROM debian:bullseye-slim as production
 COPY --from=build /out/lgtm-cat-api /

--- a/infrastructure/sentry.go
+++ b/infrastructure/sentry.go
@@ -13,12 +13,13 @@ import (
 
 const flushTimeSeconds = 2
 
-func InitSentry() (err error) {
-	defer derrors.Wrap(&err, "InitSentry")
+func InitSentry(release string) (err error) {
+	defer derrors.Wrap(&err, "InitSentry(%s)", release)
 
 	env := os.Getenv("ENV")
 	err = sentry.Init(sentry.ClientOptions{
 		Environment:      env,
+		Release:          release,
 		AttachStacktrace: true,
 		TracesSampleRate: 1.0,
 	})

--- a/main.go
+++ b/main.go
@@ -14,9 +14,12 @@ import (
 	"github.com/nekochans/lgtm-cat-api/infrastructure"
 )
 
-var uploader *manager.Uploader
-var queries *db.Queries
-var logger infrastructure.Logger
+var (
+	uploader *manager.Uploader
+	queries  *db.Queries
+	logger   infrastructure.Logger
+	release  string
+)
 
 func main() {
 	queries = infrastructure.NewSqlcQueries()
@@ -29,7 +32,7 @@ func main() {
 
 	r := handler.NewRouter(uploader, queries, logger, validator)
 
-	if err := infrastructure.InitSentry(); err != nil {
+	if err := infrastructure.InitSentry(release); err != nil {
 		logger.Error(err)
 	}
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/6

# 関連URL
https://github.com/nekochans/lgtm-cat-api/pull/80 の続きの対応

# Doneの定義
デプロイ時に Sentry Release が追加されていること

# 変更点概要
リリース時に Sentry の Release を設定するために以下の変更を行った。
Release の値は Docker イメージのタグと一致させるために、`GITHUB_SHA`を利用する方針とした。

## ビルド時に sentry SDK の release の値を指定する
[Basic Options for Go | Sentry Documentation](https://docs.sentry.io/platforms/go/configuration/options/) を参考に、ビルド時に `-ldflags='-X main.release=VALUE'`を指定することで release の値 (commit hash) を指定。

> 	// If you distribute a compiled binary, it is recommended to set the
	// Release value explicitly at build time. As an example, you can use:
	//
	// 	go build -ldflags='-X main.release=VALUE'
	//
	// That will set the value of a predeclared variable 'release' in the
	// 'main' package to 'VALUE'. Then, use that variable when initializing
	// the SDK:
	//
	// 	sentry.Init(ClientOptions{Release: release})

## GitHub Actions から release の設定を行うため Sentry に以下の設定を追加
* Organization に GitHub Integration を追加し、対象の Repository lgtm-cat-api を設定
  * 参考：[Automatic Release Management | Sentry Documentation](https://docs.sentry.io/product/releases/setup/release-automation/)
* Internal Integration の設定
  * 参考 : [Sentry Release · Actions · GitHub Marketplace](https://github.com/marketplace/actions/sentry-release)

## GitHub Repository Secret への追加
下記について登録済み。
* SENTRY_AUTH_TOKEN (Sentry Internal Integration の追加により発行されたトークン)
* SENTRY_ORG

# 補足
STG にデプロイし、動作確認済み。
https://github.com/nekochans/lgtm-cat-api/actions/runs/4154316499/jobs/7186667426