### PR TITLE
ECR イメージタグを変更不可に設定したので latest タグを設定しないように変更

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -36,9 +36,8 @@ jobs:
           ECR_REPOSITORY: prod-lgtm-cat-api-nginx
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to Amazon ECR for app
@@ -49,9 +48,8 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
-          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
+          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Fetch task-definition.json

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -36,9 +36,8 @@ jobs:
           ECR_REPOSITORY: stg-lgtm-cat-api-nginx
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f docker/nginx/Dockerfile .
+          docker build --platform amd64 -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f docker/nginx/Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to Amazon ECR for app
@@ -49,9 +48,8 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           DOCKER_BUILDKIT: "1"
         run: |
-          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -f Dockerfile .
+          docker build --target production --build-arg COMMIT_HASH="$GITHUB_SHA" -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Fetch task-definition.json


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-terraform/issues/88

# 関連URL
Terraform ECR の設定変更 PR
https://github.com/nekochans/lgtm-cat-terraform/pull/89

# Doneの定義
ECR イメージタグに `latest` が設定されないようになっていること

# 変更点概要
ECR イメージタグを変更不可に設定したので latest タグを設定しないように変更

タグを変更しようとした場合、以下のエラーが表示される。
```
tag invalid: The image tag 'd0b54efd135f602646740e57f6867608b9680a2f' already exists in the 'stg-lgtm-cat-api-nginx' repository and cannot be overwritten because the repository is immutable.
```