### PR TITLE
Node.js 12 サポート終了の対応のため actions のバージョンをアップグレード

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: "ap-northeast-1"

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: "ap-northeast-1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.19'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: '1.19'
       - name: checkout
@@ -61,6 +61,6 @@ jobs:
       - name: run unit tests
         run: go test -shuffle=on -v -race -coverprofile coverage.out -covermode atomic $(go list ./... | grep -v /lgtm-cat-migration/)
       - name: upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
       - name: run go mod tidy
         run: go mod tidy && git diff -s --exit-code go.sum


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/87

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/87 の完了条件を満たしていること

# 変更点概要
Node.js 12 サポート終了の対応のため 以下の actions のバージョンをアップグレード
- aws-actions/configure-aws-credentials@v1 -> v1-node16
- actions/setup-go@v2 -> v3 
- actions/checkout@v2 -> v3
- codecov/codecov-action@v2 -> v3

workflow  ci, cd-staging を実行し、warning が表示されないことを確認済み。
https://github.com/nekochans/lgtm-cat-api/actions/runs/4333521824/jobs/7566710426
https://github.com/nekochans/lgtm-cat-api/actions/runs/4333525090/jobs/7566716075