### PR TITLE
ECS タスクの定義を追加

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -79,11 +79,10 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      - name: Fetch task-definition.json
+      - name: Subsitute environment variables in the Amazon ECS task definition
+        run: envsubst < task-definition-${{ env.ENV }}.json  > task-definition.json
         env:
-          ECS_TASK_DEFINITION: ${{ env.ENV }}-lgtm-cat-api
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_DEFINITION | jq '.taskDefinition | with_entries(select(( .key != "taskDefinitionArn") and (.key != "revision") and (.key != "status") and (.key != "requiresAttributes") and (.key != "compatibilities")))' > task-definition.json
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Fill in the new image ID in the Amazon ECS task definition for nginx
         id: task-def-nginx

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -78,11 +78,10 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
-      - name: Fetch task-definition.json
+      - name: Subsitute environment variables in the Amazon ECS task definition
+        run: envsubst < task-definition-${{ env.ENV }}.json  > task-definition.json
         env:
-          ECS_TASK_DEFINITION: ${{ env.ENV }}-lgtm-cat-api
-        run: |
-          aws ecs describe-task-definition --task-definition $ECS_TASK_DEFINITION | jq '.taskDefinition | with_entries(select(( .key != "taskDefinitionArn") and (.key != "revision") and (.key != "status") and (.key != "requiresAttributes") and (.key != "compatibilities")))' > task-definition.json
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
 
       - name: Fill in the new image ID in the Amazon ECS task definition for nginx
         id: task-def-nginx

--- a/task-definition-prod.json
+++ b/task-definition-prod.json
@@ -1,0 +1,127 @@
+{
+  "family": "prod-lgtm-cat-api",
+  "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/prod-lgtm-cat-api-ecs-task-execution-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": true,
+      "environment": [
+        {
+          "name": "ENV",
+          "value": "prod"
+        },
+        {
+          "name": "LGTM_IMAGES_CDN_DOMAIN",
+          "value": "lgtm-images.lgtmeow.com"
+        },
+        {
+          "name": "REGION",
+          "value": "ap-northeast-1"
+        },
+        {
+          "name": "UPLOAD_S3_BUCKET_NAME",
+          "value": "prod-lgtmeow-upload-images"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DB_HOSTNAME",
+          "valueFrom": "/prod/lgtm-cat/api/DB_HOSTNAME"
+        },
+        {
+          "name": "DB_NAME",
+          "valueFrom": "/prod/lgtm-cat/api/DB_NAME"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "/prod/lgtm-cat/api/DB_PASSWORD"
+        },
+        {
+          "name": "DB_USERNAME",
+          "valueFrom": "/prod/lgtm-cat/api/DB_USERNAME"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "/prod/lgtm-cat/api/SENTRY_DSN"
+        },
+        {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "/prod/lgtm-cat/api/COGNITO_USER_POOL_ID"
+        }
+      ],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "prod-lgtm-cat-api-app",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "nginx",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "80"
+        },
+        {
+          "name": "BACKEND_HOST",
+          "value": "127.0.0.1"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "prod-lgtm-cat-api-nginx",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}

--- a/task-definition-stg.json
+++ b/task-definition-stg.json
@@ -1,0 +1,127 @@
+{
+  "family": "stg-lgtm-cat-api",
+  "taskRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-role",
+  "executionRoleArn": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/stg-lgtm-cat-api-ecs-task-execution-role",
+  "networkMode": "awsvpc",
+  "volumes": [],
+  "placementConstraints": [],
+  "runtimePlatform": {
+    "cpuArchitecture": "ARM64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "containerDefinitions": [
+    {
+      "name": "app",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [],
+      "essential": true,
+      "environment": [
+        {
+          "name": "ENV",
+          "value": "stg"
+        },
+        {
+          "name": "LGTM_IMAGES_CDN_DOMAIN",
+          "value": "stg-lgtm-images.lgtmeow.com"
+        },
+        {
+          "name": "REGION",
+          "value": "ap-northeast-1"
+        },
+        {
+          "name": "UPLOAD_S3_BUCKET_NAME",
+          "value": "stg-lgtmeow-upload-images"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "secrets": [
+        {
+          "name": "DB_HOSTNAME",
+          "valueFrom": "/stg/lgtm-cat/api/DB_HOSTNAME"
+        },
+        {
+          "name": "DB_NAME",
+          "valueFrom": "/stg/lgtm-cat/api/DB_NAME"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "/stg/lgtm-cat/api/DB_PASSWORD"
+        },
+        {
+          "name": "DB_USERNAME",
+          "valueFrom": "/stg/lgtm-cat/api/DB_USERNAME"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "/stg/lgtm-cat/api/SENTRY_DSN"
+        },
+        {
+          "name": "COGNITO_USER_POOL_ID",
+          "valueFrom": "/stg/lgtm-cat/api/COGNITO_USER_POOL_ID"
+        }
+      ],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "stg-lgtm-cat-api-app",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    },
+    {
+      "name": "nginx",
+      "image": "",
+      "cpu": 0,
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 80,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "environment": [
+        {
+          "name": "PORT",
+          "value": "80"
+        },
+        {
+          "name": "BACKEND_HOST",
+          "value": "127.0.0.1"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [
+        {
+          "name": "nofile",
+          "softLimit": 1024000,
+          "hardLimit": 1024000
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "stg-lgtm-cat-api-nginx",
+          "awslogs-region": "ap-northeast-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/lgtm-cat-api/issues/85

# Doneの定義
https://github.com/nekochans/lgtm-cat-api/issues/85 の完了の定義が満たされていること

# 変更点概要
Terraform で管理していた ECS タスクの定義をアプリケーション側で管理できるように変更。
STG,PROD 環境用のタスクの定義の JSON ファイルを追加し、CD の設定を変更。

# レビュアーに重点的にチェックして欲しい点
Terraform の修正 PR についても確認よろしくです！
https://github.com/nekochans/lgtm-cat-terraform/pull/95